### PR TITLE
Added cell declaration to imports 

### DIFF
--- a/examples/02_construct_simple_pc.py
+++ b/examples/02_construct_simple_pc.py
@@ -7,6 +7,9 @@ In this tutorial, you will learn about the basic APIs to construct PCs.
 
 # sphinx_gallery_thumbnail_path = 'imgs/juice.png'
 
+# %% 
+# Let's start by importing the necessary packages.
+
 import torch
 import pyjuice as juice
 import pyjuice.nodes.distributions as dists

--- a/examples/03_construct_hmm.py
+++ b/examples/03_construct_hmm.py
@@ -7,6 +7,9 @@ This tutorial demonstrates how to construct an HMM with :code:`pyjuice.inputs`, 
 
 # sphinx_gallery_thumbnail_path = 'imgs/juice.png'
 
+# %% 
+# Let's start by importing the necessary packages.
+
 import torch
 import pyjuice as juice
 import pyjuice.nodes.distributions as dists

--- a/examples/05_common_transformations.py
+++ b/examples/05_common_transformations.py
@@ -7,6 +7,9 @@ In this tutorial, you will learn how to use the built-in structural transformati
 
 # sphinx_gallery_thumbnail_path = 'imgs/juice.png'
 
+# %% 
+# Let's start by importing the necessary packages.
+
 import torch
 import pyjuice as juice
 import pyjuice.nodes.distributions as dists


### PR DESCRIPTION
The imports of the adapted examples where not incl. in cells yet. This way, they were not executable as notebook.

Therefore, I've added a cell declaration to make the examples executable as notebooks. 

I've added a generic comment on the cells content. 